### PR TITLE
adding tag _jsonparsefailure for failures in json-codecs

### DIFF
--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -35,7 +35,7 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
       yield LogStash::Event.new(LogStash::Json.load(data))
     rescue LogStash::Json::ParserError => e
       @logger.info("JSON parse failure. Falling back to plain-text", :error => e, :data => data)
-      yield LogStash::Event.new("message" => data)
+      yield LogStash::Event.new("message" => data, "tags" => "_jsonparsefailure")
     end
   end # def decode
 

--- a/spec/codecs/json_spec.rb
+++ b/spec/codecs/json_spec.rb
@@ -46,6 +46,7 @@ describe LogStash::Codecs::JSON do
           decoded = true
           insist { event.is_a?(LogStash::Event) }
           insist { event["message"] } == "something that isn't json"
+          insist { event["tags"] }.include?("_jsonparsefailure")
         end
         insist { decoded } == true
       end


### PR DESCRIPTION
@mluebcke
Logstash moved plugins to their own repositories.

moved PR from: https://github.com/elasticsearch/logstash/pull/1091
