### PR TITLE
Robust parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
+* 1.1.0
+  - Handle scalar types (string/number) and be more defensive about crashable errors
 * 1.0.1
   - Handle JSON arrays at source root by emitting multiple events

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json'
-  s.version         = '1.0.1'
+  s.version         = '1.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec may be used to decode (via inputs) and encode (via outputs) full JSON messages"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/json_spec.rb
+++ b/spec/codecs/json_spec.rb
@@ -52,6 +52,36 @@ describe LogStash::Codecs::JSON do
       end
     end
 
+    describe "scalar values" do
+      shared_examples "given a value" do |value_arg|
+        context "where value is #{value_arg}" do
+          let(:value) { value_arg }
+          let(:event) { LogStash::Event.new(value) }
+          let(:value_json) { LogStash::Json.dump(value)}
+          let(:event) do
+            e = nil
+            subject.decode(value_json) do |decoded|
+              e = decoded
+            end
+            e
+          end
+
+          it "should store the value in 'message'" do
+            expect(event["message"]).to eql(value_json)
+          end
+
+          it "should have the json parse failure tag" do
+            expect(event["tags"]).to include("_jsonparsefailure")
+          end
+        end
+      end
+
+      include_examples "given a value", 123
+      include_examples "given a value", "hello"
+      include_examples "given a value", "-1"
+      include_examples "given a value", " "
+    end
+
     context "processing JSON with an array root" do
       let(:data) {
         [


### PR DESCRIPTION
This fixes #5 .

It's an open question as to whether scalar values should be parsed. I am of the opinion that they SHOULD be parsed, because the feedback mechanism for errors is more clear (Why are these non-json strings showing up in my output?) vs. (Hmmm there's some odd stuff in the debug log). I'm open to differing views here however.
