### PR TITLE
use correct event for json verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+## 2.0.3
+ - fixed a spec, no change in functionality
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 
-* 1.1.0
+## 1.1.0
   - Handle scalar types (string/number) and be more defensive about crashable errors
-* 1.0.1
+
+## 1.0.1
   - Handle JSON arrays at source root by emitting multiple events

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec may be used to decode (via inputs) and encode (via outputs) full JSON messages"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/json_spec.rb
+++ b/spec/codecs/json_spec.rb
@@ -153,7 +153,7 @@ describe LogStash::Codecs::JSON do
       event = LogStash::Event.new(data)
       got_event = false
       subject.on_event do |e, d|
-        insist { d.chomp } == LogStash::Event.new(data).to_json
+        insist { d.chomp } == event.to_json
         insist { LogStash::Json.load(d)["foo"] } == data["foo"]
         insist { LogStash::Json.load(d)["baz"] } == data["baz"]
         insist { LogStash::Json.load(d)["bah"] } == data["bah"]


### PR DESCRIPTION
this spec was incorrect but actually passing with the current Event implementation. It was working because it was relying on the mutation of the `data` hash which picked up the `@timestamp` field from the first `LogStash::Event.new(data)` call and eventually the second `LogStash::Event.new(data).to_json` reused that `@timestamp` and resulted in the same json. this is clearly not the intent and it is not working with the new Event implementation in elastic/logstash#4123
