### PR TITLE
use Event#from_json if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+ - Backward compatible support for `Event#from_json` method https://github.com/logstash-plugins/logstash-codec-json/pull/21
+
 ## 2.0.4
  - Reduce the size of the gem by removing the vendor files
 

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -1,17 +1,17 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json'
-  s.version         = '2.0.4'
+  s.version         = '2.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec may be used to decode (via inputs) and encode (via outputs) full JSON messages"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
   s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
-  s.require_paths = ["lib"]
+  s.require_paths   = ["lib"]
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*','spec/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})

--- a/spec/codecs/json_spec.rb
+++ b/spec/codecs/json_spec.rb
@@ -6,161 +6,186 @@ require "insist"
 
 describe LogStash::Codecs::JSON do
   subject do
-    next LogStash::Codecs::JSON.new
+    LogStash::Codecs::JSON.new
   end
 
-  context "#decode" do
-    it "should return an event from json data" do
-      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
-      subject.decode(LogStash::Json.dump(data)) do |event|
-        insist { event.is_a? LogStash::Event }
-        insist { event["foo"] } == data["foo"]
-        insist { event["baz"] } == data["baz"]
-        insist { event["bah"] } == data["bah"]
-      end
-    end
+  shared_examples :codec do
 
-    it "should be fast", :performance => true do
-      json = '{"message":"Hello world!","@timestamp":"2013-12-21T07:01:25.616Z","@version":"1","host":"Macintosh.local","sequence":1572456}'
-      iterations = 500000
-      count = 0
-
-      # Warmup
-      10000.times { subject.decode(json) { } }
-
-      start = Time.now
-      iterations.times do
-        subject.decode(json) do |event|
-          count += 1
-        end
-      end
-      duration = Time.now - start
-      insist { count } == iterations
-      puts "codecs/json rate: #{"%02.0f/sec" % (iterations / duration)}, elapsed: #{duration}s"
-    end
-
-    context "processing plain text" do
-      it "falls back to plain text" do
-        decoded = false
-        subject.decode("something that isn't json") do |event|
-          decoded = true
-          insist { event.is_a?(LogStash::Event) }
-          insist { event["message"] } == "something that isn't json"
-          insist { event["tags"] }.include?("_jsonparsefailure")
-        end
-        insist { decoded } == true
-      end
-    end
-
-    describe "scalar values" do
-      shared_examples "given a value" do |value_arg|
-        context "where value is #{value_arg}" do
-          let(:value) { value_arg }
-          let(:event) { LogStash::Event.new(value) }
-          let(:value_json) { LogStash::Json.dump(value)}
-          let(:event) do
-            e = nil
-            subject.decode(value_json) do |decoded|
-              e = decoded
-            end
-            e
-          end
-
-          it "should store the value in 'message'" do
-            expect(event["message"]).to eql(value_json)
-          end
-
-          it "should have the json parse failure tag" do
-            expect(event["tags"]).to include("_jsonparsefailure")
-          end
+    context "#decode" do
+      it "should return an event from json data" do
+        data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
+        subject.decode(LogStash::Json.dump(data)) do |event|
+          insist { event.is_a? LogStash::Event }
+          insist { event["foo"] } == data["foo"]
+          insist { event["baz"] } == data["baz"]
+          insist { event["bah"] } == data["bah"]
         end
       end
 
-      include_examples "given a value", 123
-      include_examples "given a value", "hello"
-      include_examples "given a value", "-1"
-      include_examples "given a value", " "
-    end
-
-    context "processing JSON with an array root" do
-      let(:data) {
-        [
-          {"foo" => "bar"},
-          {"foo" => "baz"}
-        ]
-      }
-      let(:data_json) {
-        LogStash::Json.dump(data)
-      }
-
-      it "should yield multiple events" do
+      it "should be fast", :performance => true do
+        json = '{"message":"Hello world!","@timestamp":"2013-12-21T07:01:25.616Z","@version":"1","host":"Macintosh.local","sequence":1572456}'
+        iterations = 500000
         count = 0
-        subject.decode(data_json) do |event|
-          count += 1
+
+        # Warmup
+        10000.times { subject.decode(json) { } }
+
+        start = Time.now
+        iterations.times do
+          subject.decode(json) do |event|
+            count += 1
+          end
         end
-        expect(count).to eql(data.count)
+        duration = Time.now - start
+        insist { count } == iterations
+        puts "codecs/json rate: #{"%02.0f/sec" % (iterations / duration)}, elapsed: #{duration}s"
       end
 
-      it "should yield the correct objects" do
-        index = 0
-        subject.decode(data_json) do |event|
-          expect(event.to_hash).to include(data[index])
-          index += 1
+      context "processing plain text" do
+        it "falls back to plain text" do
+          decoded = false
+          subject.decode("something that isn't json") do |event|
+            decoded = true
+            insist { event.is_a?(LogStash::Event) }
+            insist { event["message"] } == "something that isn't json"
+            insist { event["tags"] }.include?("_jsonparsefailure")
+          end
+          insist { decoded } == true
+        end
+      end
+
+      describe "scalar values" do
+        shared_examples "given a value" do |value_arg|
+          context "where value is #{value_arg}" do
+            let(:value) { value_arg }
+            let(:event) { LogStash::Event.new(value) }
+            let(:value_json) { LogStash::Json.dump(value)}
+            let(:event) do
+              e = nil
+              subject.decode(value_json) do |decoded|
+                e = decoded
+              end
+              e
+            end
+
+            it "should store the value in 'message'" do
+              expect(event["message"]).to eql(value_json)
+            end
+
+            it "should have the json parse failure tag" do
+              expect(event["tags"]).to include("_jsonparsefailure")
+            end
+          end
+        end
+
+        include_examples "given a value", 123
+        include_examples "given a value", "hello"
+        include_examples "given a value", "-1"
+        include_examples "given a value", " "
+      end
+
+      context "processing JSON with an array root" do
+        let(:data) {
+          [
+            {"foo" => "bar"},
+            {"foo" => "baz"}
+          ]
+        }
+        let(:data_json) {
+          LogStash::Json.dump(data)
+        }
+
+        it "should yield multiple events" do
+          count = 0
+          subject.decode(data_json) do |event|
+            count += 1
+          end
+          expect(count).to eql(data.count)
+        end
+
+        it "should yield the correct objects" do
+          index = 0
+          subject.decode(data_json) do |event|
+            expect(event.to_hash).to include(data[index])
+            index += 1
+          end
+        end
+      end
+
+      context "processing weird binary blobs" do
+        it "falls back to plain text and doesn't crash (LOGSTASH-1595)" do
+          decoded = false
+          blob = (128..255).to_a.pack("C*").force_encoding("ASCII-8BIT")
+          subject.decode(blob) do |event|
+            decoded = true
+            insist { event.is_a?(LogStash::Event) }
+            insist { event["message"].encoding.to_s } == "UTF-8"
+          end
+          insist { decoded } == true
+        end
+      end
+
+      context "when json could not be parsed" do
+
+        let(:message)    { "random_message" }
+
+        it "add the failure tag" do
+          subject.decode(message) do |event|
+            expect(event).to include "tags"
+          end
+        end
+
+        it "uses an array to store the tags" do
+          subject.decode(message) do |event|
+            expect(event['tags']).to be_a Array
+          end
+        end
+
+        it "add a json parser failure tag" do
+          subject.decode(message) do |event|
+            expect(event['tags']).to include "_jsonparsefailure"
+          end
         end
       end
     end
 
-    context "processing weird binary blobs" do
-      it "falls back to plain text and doesn't crash (LOGSTASH-1595)" do
-        decoded = false
-        blob = (128..255).to_a.pack("C*").force_encoding("ASCII-8BIT")
-        subject.decode(blob) do |event|
-          decoded = true
-          insist { event.is_a?(LogStash::Event) }
-          insist { event["message"].encoding.to_s } == "UTF-8"
+    context "#encode" do
+      it "should return json data" do
+        data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
+        event = LogStash::Event.new(data)
+        got_event = false
+        subject.on_event do |e, d|
+          insist { d.chomp } == event.to_json
+          insist { LogStash::Json.load(d)["foo"] } == data["foo"]
+          insist { LogStash::Json.load(d)["baz"] } == data["baz"]
+          insist { LogStash::Json.load(d)["bah"] } == data["bah"]
+          got_event = true
         end
-        insist { decoded } == true
+        subject.encode(event)
+        insist { got_event }
       end
     end
+  end
 
-    context "when json could not be parsed" do
-
-      let(:message)    { "random_message" }
-
-      it "add the failure tag" do
-        subject.decode(message) do |event|
-          expect(event).to include "tags"
-        end
-      end
-
-      it "uses an array to store the tags" do
-        subject.decode(message) do |event|
-          expect(event['tags']).to be_a Array
-        end
-      end
-
-      it "add a json parser failure tag" do
-        subject.decode(message) do |event|
-          expect(event['tags']).to include "_jsonparsefailure"
+  context "forcing legacy parsing" do
+    it_behaves_like :codec do
+      before(:each) do
+        # stub codec parse method to force use of the legacy parser.
+        # this is very implementation specific but I am not sure how
+        # this can be tested otherwise.
+        allow(subject).to receive(:parse) do |data, &block|
+          subject.send(:legacy_parse, data, &block)
         end
       end
     end
   end
 
-  context "#encode" do
-    it "should return json data" do
-      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
-      event = LogStash::Event.new(data)
-      got_event = false
-      subject.on_event do |e, d|
-        insist { d.chomp } == event.to_json
-        insist { LogStash::Json.load(d)["foo"] } == data["foo"]
-        insist { LogStash::Json.load(d)["baz"] } == data["baz"]
-        insist { LogStash::Json.load(d)["bah"] } == data["bah"]
-        got_event = true
-      end
-      subject.encode(event)
-      insist { got_event }
+  context "default parser choice" do
+    # here we cannot force the use of the Event#from_json since if this test is run in the
+    # legacy context (no Java Event) it will fail but if in the new context, it will be picked up.
+    it_behaves_like :codec do
+      # do nothing
     end
   end
+
 end


### PR DESCRIPTION
relates to https://github.com/elastic/logstash/pull/4631and elastic/logstash#4595

similar PR as logstash-plugins/logstash-codec-json_lines/pull/19 to support the new `Event#from_json` if available when using the Java Event.
