### PR TITLE
Change log level back to info.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.4
+  - Made 'Falling back to plain-text' log message an 'info' level log. This was
+    'error' for versions v2.1.0 through v2.1.3 (and was 'info' before that).
+
 # 2.1.3
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.1.2

--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -64,7 +64,7 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
       yield LogStash::Event.new("message" => json, "tags" => ["_jsonparsefailure"])
     end
   rescue LogStash::Json::ParserError => e
-    @logger.error("JSON parse failure. Falling back to plain-text", :error => e, :data => json)
+    @logger.info("JSON parse failure. Falling back to plain-text", :error => e, :data => json)
     yield LogStash::Event.new("message" => json, "tags" => ["_jsonparsefailure"])
   rescue StandardError => e
     # This should NEVER happen. But hubris has been the cause of many pipeline breaking things

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json'
-  s.version         = '2.1.3'
+  s.version         = '2.1.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec may be used to decode (via inputs) and encode (via outputs) full JSON messages"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
It was info level before v2.1.0 of this plugin. I believe that the
'falling back to plain-text' message is informational, not an error
worth concerning users, because Logstash will correct for it without any
user intervention. Users wishing to debug logstash configuration will
see this when --verbose flag is used.
