### PR TITLE
Feat: event target => namespace support (for ECS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+  - Feat: event `target => namespace` support (for ECS) [#37](https://github.com/logstash-plugins/logstash-codec-json/pull/37)
+  - Refactor: dropped support for old Logstash versions (< 6.0)
+
 ## 3.0.5
   - Update gemspec summary
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -38,10 +38,26 @@ failure, the payload will be stored in the `message` field.
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
 
 &nbsp;
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names
+    ** `v1`: Elastic Common Schema compliant behavior (warns when `target` isn't set)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+See <<plugins-{type}s-{plugin}-ecs_metadata>> for detailed information.
 
 [id="plugins-{type}s-{plugin}-charset"]
 ===== `charset` 
@@ -58,5 +74,24 @@ weird cases like this, you can set the `charset` setting to the
 actual encoding of the text and Logstash will convert it for you.
 
 For nxlog users, you may to set this to "CP1252".
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Define the target field for placing the parsed data. If this setting is not
+set, the JSON data will be stored at the root (top level) of the event.
+
+For example, if you want data to be put under the `redis` field:
+[source,ruby]
+    input {
+      redis {
+        codec => json {
+          target => "[redis]"
+        }
+      }
+    }
 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -83,14 +83,13 @@ For nxlog users, you may to set this to "CP1252".
 Define the target field for placing the parsed data. If this setting is not
 set, the JSON data will be stored at the root (top level) of the event.
 
-For example, if you want data to be put under the `redis` field:
+For example, if you want data to be put under the `document` field:
 [source,ruby]
     input {
-      redis {
+      http {
         codec => json {
-          target => "[redis]"
+          target => "[document]"
         }
       }
     }
-
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -45,19 +45,6 @@ failure, the payload will be stored in the `message` field.
 
 &nbsp;
 
-[id="plugins-{type}s-{plugin}-ecs_compatibility"]
-===== `ecs_compatibility`
-
-  * Value type is <<string,string>>
-  * Supported values are:
-    ** `disabled`: does not use ECS-compatible field names
-    ** `v1`: Elastic Common Schema compliant behavior (warns when `target` isn't set)
-  * Default value depends on which version of Logstash is running:
-    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
-    ** Otherwise, the default value is `disabled`
-
-Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
-
 [id="plugins-{type}s-{plugin}-charset"]
 ===== `charset` 
 
@@ -73,6 +60,19 @@ weird cases like this, you can set the `charset` setting to the
 actual encoding of the text and Logstash will convert it for you.
 
 For nxlog users, you may to set this to "CP1252".
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: does not use ECS-compatible field names
+** `v1`: Elastic Common Schema compliant behavior (warns when `target` isn't set)
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-target"]
 ===== `target`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -64,13 +64,13 @@ For nxlog users, you may to set this to "CP1252".
 [id="plugins-{type}s-{plugin}-ecs_compatibility"]
 ===== `ecs_compatibility`
 
-* Value type is <<string,string>>
-* Supported values are:
-** `disabled`: does not use ECS-compatible field names
-** `v1`: Elastic Common Schema compliant behavior (warns when `target` isn't set)
-* Default value depends on which version of Logstash is running:
-** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
-** Otherwise, the default value is `disabled`
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names
+    ** `v1`,`v8`: Elastic Common Schema compliant behavior (warns when `target` isn't set)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -66,7 +66,7 @@ For nxlog users, you may to set this to "CP1252".
 
   * Value type is <<string,string>>
   * Supported values are:
-    ** `disabled`: does not use ECS-compatible field names
+    ** `disabled`: JSON document data added at root level
     ** `v1`,`v8`: Elastic Common Schema compliant behavior (warns when `target` isn't set)
   * Default value depends on which version of Logstash is running:
     ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -38,8 +38,8 @@ failure, the payload will be stored in the `message` field.
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
 
@@ -92,4 +92,3 @@ For example, if you want data to be put under the `document` field:
         }
       }
     }
-

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -57,7 +57,6 @@ failure, the payload will be stored in the `message` field.
     ** Otherwise, the default value is `disabled`
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
-See <<plugins-{type}s-{plugin}-ecs_metadata>> for detailed information.
 
 [id="plugins-{type}s-{plugin}-charset"]
 ===== `charset` 

--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -54,43 +54,25 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
 
   private
 
-  def from_json_parse(json, &block)
-    LogStash::Event.from_json(json).each { |event| yield event }
-  rescue LogStash::Json::ParserError => e
-    @logger.error("JSON parse error, original data now in message field",
-        :exception => e.class, :message => e.message, :data => json)
-    yield LogStash::Event.new("message" => json, "tags" => ["_jsonparsefailure"])
-  end
-
-  def legacy_parse(json, &block)
+  def parse(json)
     decoded = LogStash::Json.load(json)
 
     case decoded
     when Array
-      decoded.each {|item| yield(LogStash::Event.new(item)) }
+      decoded.each { |item| yield(LogStash::Event.new(item)) }
     when Hash
       yield LogStash::Event.new(decoded)
     else
-      @logger.error("JSON codec is expecting array or object/map", :data => json)
-      yield LogStash::Event.new("message" => json, "tags" => ["_jsonparsefailure"])
+      @logger.error("JSON type error, original data now in message field", type: decoded.class, data: json)
+      yield parse_error_event(json)
     end
   rescue LogStash::Json::ParserError => e
-    @logger.info("JSON parse failure. Falling back to plain-text", :error => e, :data => json)
-    yield LogStash::Event.new("message" => json, "tags" => ["_jsonparsefailure"])
-  rescue StandardError => e
-    # This should NEVER happen. But hubris has been the cause of many pipeline breaking things
-    # If something bad should happen we just don't want to crash logstash here.
-    @logger.warn(
-      "An unexpected error occurred parsing JSON data",
-      :data => json,
-      :message => e.message,
-      :class => e.class.name,
-      :backtrace => e.backtrace
-    )
+    @logger.error("JSON parse error, original data now in message field", message: e.message, data: json)
+    yield parse_error_event(json)
   end
 
-  # keep compatibility with all v2.x distributions. only in 2.3 will the Event#from_json method be introduced
-  # and we need to keep compatibility for all v2 releases.
-  alias_method :parse, LogStash::Event.respond_to?(:from_json) ? :from_json_parse : :legacy_parse
+  def parse_error_event(json)
+    LogStash::Event.new("message" => json, "tags" => ["_jsonparsefailure"])
+  end
 
 end

--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -66,8 +66,8 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
       @logger.error("JSON type error, original data now in message field", type: decoded.class, data: json)
       yield parse_error_event(json)
     end
-  rescue LogStash::Json::ParserError => e
-    @logger.error("JSON parse error, original data now in message field", message: e.message, data: json)
+  rescue => e
+    @logger.error("JSON parse error, original data now in message field", message: e.message, exception: e.class, data: json)
     yield parse_error_event(json)
   end
 

--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -46,8 +46,6 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
   # Defines a target field for placing decoded fields.
   # If this setting is omitted, data gets stored at the root (top level) of the event.
   # The target is only relevant while decoding data into a new event.
-  #
-  # NOTE: if the `target` field already exists, it will be overwritten!
   config :target, :validate => :field_reference
 
   def register

--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -53,8 +53,6 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
   def register
     @converter = LogStash::Util::Charset.new(@charset)
     @converter.logger = @logger
-
-    event_factory_builder.with_target(target).build # sets @event_factory
   end
 
   def decode(data, &block)
@@ -68,7 +66,7 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
   private
 
   def parse_json(json)
-    events_from_json(json).each { |event| yield event }
+    events_from_json(json, targeted_event_factory).each { |event| yield event }
   rescue => e
     @logger.error("JSON parse error, original data now in message field", message: e.message, exception: e.class, data: json)
     yield parse_json_error_event(json)

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -19,9 +19,12 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "codec" }
 
+  s.required_ruby_version = '>= 2.3' # Event.from_json exists at least since LS 5.6
+
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", "< 2"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", "< 2"
+  s.add_runtime_dependency "logstash-mixin-event_support", "< 2"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", "< 2"
-  s.add_runtime_dependency "logstash-mixin-event_support", "< 2"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json'
-  s.version         = '3.0.5'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads JSON formatted content, creating one event per element in a JSON array"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'

--- a/spec/codecs/json_spec.rb
+++ b/spec/codecs/json_spec.rb
@@ -5,8 +5,11 @@ require "logstash/json"
 require "insist"
 
 describe LogStash::Codecs::JSON do
+
+  let(:options) { Hash.new }
+
   subject do
-    LogStash::Codecs::JSON.new
+    LogStash::Codecs::JSON.new(options)
   end
 
   shared_examples :codec do
@@ -127,7 +130,7 @@ describe LogStash::Codecs::JSON do
 
       context "when json could not be parsed" do
 
-        let(:message)    { "random_message" }
+        let(:message) { "random_message" }
 
         it "add the failure tag" do
           subject.decode(message) do |event|
@@ -167,25 +170,8 @@ describe LogStash::Codecs::JSON do
     end
   end
 
-  context "forcing legacy parsing" do
-    it_behaves_like :codec do
-      before(:each) do
-        # stub codec parse method to force use of the legacy parser.
-        # this is very implementation specific but I am not sure how
-        # this can be tested otherwise.
-        allow(subject).to receive(:parse) do |data, &block|
-          subject.send(:legacy_parse, data, &block)
-        end
-      end
-    end
-  end
-
   context "default parser choice" do
-    # here we cannot force the use of the Event#from_json since if this test is run in the
-    # legacy context (no Java Event) it will fail but if in the new context, it will be picked up.
-    it_behaves_like :codec do
-      # do nothing
-    end
+    it_behaves_like :codec
   end
 
 end


### PR DESCRIPTION
We're introducing a `target => ...` configuration option for the codec, to aid ECS support.
When `target` isn't set in ECS mode, we do the usual [info log message](https://github.com/logstash-plugins/logstash-mixin-ecs_compatibility_support/pull/6).

The code is relying on our new [plugin mixin](https://github.com/logstash-plugins/logstash-mixin-event_support/pull/2) to provide `event_factory.new_event` support.

Performance numbers were posted on https://github.com/logstash-plugins/logstash-mixin-event_support/pull/2