### PR TITLE
Fix: json parsing compatibility + freeze event.original value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.1.0
   - Feat: event `target => namespace` support (for ECS) [#37](https://github.com/logstash-plugins/logstash-codec-json/pull/37)
   - Refactor: dropped support for old Logstash versions (< 6.0)
-  - Deps: pull in json parsing compatibility fix [#38](https://github.com/logstash-plugins/logstash-codec-json/pull/38)
+  - Fix: json parsing compatibility + freeze event.original value [#38](https://github.com/logstash-plugins/logstash-codec-json/pull/38)
 
 ## 3.0.5
   - Update gemspec summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.1.0
   - Feat: event `target => namespace` support (for ECS) [#37](https://github.com/logstash-plugins/logstash-codec-json/pull/37)
   - Refactor: dropped support for old Logstash versions (< 6.0)
+  - Deps: pull in json parsing compatibility fix [#38](https://github.com/logstash-plugins/logstash-codec-json/pull/38)
 
 ## 3.0.5
   - Update gemspec summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.1.0
   - Feat: event `target => namespace` support (for ECS) [#37](https://github.com/logstash-plugins/logstash-codec-json/pull/37)
   - Refactor: dropped support for old Logstash versions (< 6.0)
-  - Fix: json parsing compatibility + freeze event.original value [#38](https://github.com/logstash-plugins/logstash-codec-json/pull/38)
+  - Fix: json parsing compatibility (when parsing blank strings) + freeze event.original value [#38](https://github.com/logstash-plugins/logstash-codec-json/pull/38)
 
 ## 3.0.5
   - Update gemspec summary

--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -75,7 +75,7 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
     events = events_from_json(json, targeted_event_factory)
     if events.size == 1
       event = events.first
-      event.set(@original_field, json.freeze) if @original_field
+      event.set(@original_field, json.dup.freeze) if @original_field
       yield event
     else
       events.each { |event| yield event }

--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -75,7 +75,7 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
     events = events_from_json(json, targeted_event_factory)
     if events.size == 1
       event = events.first
-      event.set(@original_field, json) if @original_field
+      event.set(@original_field, json.freeze) if @original_field
       yield event
     else
       events.each { |event| yield event }

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
-  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
In 1.0.0 the mixin shipped with a JSON parsing helper, this method did not parse empty strings in a compatible way.
The desired behavior is to parse `""` as a `nil` and raise no error while doing so (to behave like `Event.from_json` impl).

Pulling in https://github.com/logstash-plugins/logstash-mixin-event_support/pull/3 on top of https://github.com/logstash-plugins/logstash-codec-json/pull/37

Also added `value.dup.freeze` for `event.original`'s value.

NOTE: we haven't released **3.1.0** yet - this PR will be part of the same release.