### PR TITLE
fix: do not overwrite [event][original] decoded from payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.1
-  - Fix: when decoded JSON includes an `[event][original]` field, having `ecs_compatibility` enabled will no longer overwrite the decoded field
+  - Fix: when decoded JSON includes an `[event][original]` field, having `ecs_compatibility` enabled will no longer overwrite the decoded field [#43](https://github.com/logstash-plugins/logstash-codec-json/pull/43)
 
 ## 3.1.0
   - Feat: event `target => namespace` support (for ECS) [#37](https://github.com/logstash-plugins/logstash-codec-json/pull/37)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1
+  - Fix: when decoded JSON includes an `[event][original]` field, having `ecs_compatibility` enabled will no longer overwrite the decoded field
+
 ## 3.1.0
   - Feat: event `target => namespace` support (for ECS) [#37](https://github.com/logstash-plugins/logstash-codec-json/pull/37)
   - Refactor: dropped support for old Logstash versions (< 6.0)

--- a/lib/logstash/codecs/json.rb
+++ b/lib/logstash/codecs/json.rb
@@ -75,7 +75,7 @@ class LogStash::Codecs::JSON < LogStash::Codecs::Base
     events = events_from_json(json, targeted_event_factory)
     if events.size == 1
       event = events.first
-      event.set(@original_field, json.dup.freeze) if @original_field
+      event.set(@original_field, json.dup.freeze) if @original_field && !event.include?(@original_field)
       yield event
     else
       events.each { |event| yield event }

--- a/logstash-codec-json.gemspec
+++ b/logstash-codec-json.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json'
-  s.version         = '3.1.0'
+  s.version         = '3.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads and writes JSON formatted content; one event per element in a JSON array"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/json_spec.rb
+++ b/spec/codecs/json_spec.rb
@@ -222,6 +222,19 @@ describe LogStash::Codecs::JSON, :ecs_compatibility_support do
 
         end
 
+        context 'when JSON-coded event includes [event][original]' do
+          let(:message) { ' { "foo": "bar", "baz": { "0": [1, 2, 3], "1": true }, "event" : { "original" : "actual_original" } } ' }
+
+          it 'does not overwrite [event][original]' do
+            count = 0
+            subject.decode(message) do |event|
+              count += 1
+              expect( event.get('[event][original]') ).to eq("actual_original")
+            end
+            expect( count ).to eql 1
+          end
+        end
+
       end
     end
 


### PR DESCRIPTION
In v3.1.0 of this plugin, we introduced `ecs_compatibility` support, so that when run in a pipeline for which `ecs_compatibility` was enabled (opt-in for Logstash 7.x, default in Logstash 8.x) this plugin would record the original bytes used to generated the bytes into the nested `[event][original]` field.

Unfortunately, this _overwrites_ a value encoded at that address if the object represented by the JSON string we parsed included it.

Here we constrain the codec to only set the `[event][original]` when it is _not_ present in the decoded payload.

***

Until this is merged and released, or for users who cannot upgrade their plugins, a work-around would be to instantiate the codec with `ecs_compatibility` explicitly disabled:

~~~
    codec => json { ecs_compatibility => disabled }
~~~